### PR TITLE
Submit transactions to different (round-robin) nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# To run
+
+1. Spin up nodes
+```
+> docker-compose up
+```
+
+2. Start sending transactions
+```
+> node src/app.js --help
+> node src/app.js \
+    --fund \
+    --period 100 \
+    --address 127.0.0.1:9944 127.0.0.1:9945 127.0.0.1:9946 \
+    --log-level trace
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,24 @@
 version: '3'
-services: 
+services:
   boot-node-1:
     image: plugnet/plugblockchain:1.0.0-rc1
     container_name: boot-node-1
     volumes: ["./data/boot-node-1:/mnt/node"]
     command:
       - /usr/local/bin/substrate
-      - /usr/local/bin/substrate
       - --base-path=/mnt/node
       - --chain=dev
       - --validator
       - --ws-external
-      - --ws-port=9944 
+      - --ws-port=9944
       - --rpc-external
       - --rpc-cors=all
       - --bootnodes=/dns4/boot-node-3/tcp/30333/p2p/QmdoyqhDeYScKjNKZTK9Ru3KugwXxiUBaS2k9CESDbn3Be
       # Some arbitrary static bytes to set the libp2p public key
       - --node-key=D0FE7E415AA9BAD7605A6841E74C2E0BA72DA1367BBA28AA37DC044669D09858
-    
+    ports:
+      - "9945:9944"
+
   boot-node-2:
     image: plugnet/plugblockchain:1.0.0-rc1
     container_name: boot-node-2
@@ -28,7 +29,7 @@ services:
       - --chain=dev
       - --validator
       - --ws-external
-      - --ws-port=9944 
+      - --ws-port=9944
       - --rpc-external
       - --rpc-cors=all
       - --bootnodes=/dns4/boot-node-3/tcp/30333/p2p/QmdoyqhDeYScKjNKZTK9Ru3KugwXxiUBaS2k9CESDbn3Be
@@ -50,12 +51,14 @@ services:
       - --chain=dev
       - --validator
       - --ws-external
-      - --ws-port=9944 
+      - --ws-port=9944
       - --rpc-external
       - --rpc-cors=all
       # Some arbitrary static bytes to set the libp2p public key
       - --node-key=D0FE7E415AA9BAD7605A6841E74C2E0BA72DA1367BBA28AA37DC044669D09860
-  
+    ports:
+      - "9946:9944"
+
   validator-node-1:
     image: plugnet/plugblockchain:1.0.0-rc1
     container_name: validator-node-1
@@ -69,7 +72,7 @@ services:
       - --validator
       - --ws-external
       - --rpc-cors=all
-  
+
   validator-node-2:
     image: plugnet/plugblockchain:1.0.0-rc1
     container_name: validator-node-2
@@ -97,7 +100,7 @@ services:
       - --validator
       - --ws-external
       - --rpc-cors=all
-    
+
   validator-node-4:
     image: plugnet/plugblockchain:1.0.0-rc1
     container_name: validator-node-4
@@ -126,55 +129,3 @@ services:
       - --ws-external
       - --rpc-cors=all
       - -log=error
-
-  # full-node-1:
-  #   image: plugnet/plugblockchain:1.0.0-rc1
-  #   container_name: full-node-1
-  #   volumes: ["./data/full-node-1:/mnt/node"]
-  #   command:
-      - /usr/local/bin/substrate
-  #     - --base-path=/mnt/node
-  #     - --chain=dev
-  #     - --bootnodes=/dns4/boot-node-1/tcp/30333/p2p/QmQmJTi2eDg53Ws3N5XaixMmiGCmhNNJX7bPBMirnD2JEs
-  #     - --ws-external
-  #     - --rpc-cors=all
-  #     - -lafg
-
-  # full-node-2:
-  #   image: plugnet/plugblockchain:1.0.0-rc1
-  #   container_name: full-node-2
-  #   volumes: ["./data/full-node-2:/mnt/node"]
-  #   command:
-      - /usr/local/bin/substrate
-  #     - --base-path=/mnt/node
-  #     - --chain=dev
-  #     - --bootnodes=/dns4/boot-node-1/tcp/30333/p2p/QmQmJTi2eDg53Ws3N5XaixMmiGCmhNNJX7bPBMirnD2JEs
-  #     - --ws-external
-  #     - --rpc-cors=all
-
-  # full-node-1:
-  #   image: plugnet/plugblockchain:1.0.0-rc1
-  #   container_name: full-node-1
-  #   volumes: ["./data/full-node-1:/mnt/node"]
-  #   command:
-      - /usr/local/bin/substrate
-  #     - --base-path=/mnt/node
-  #     - --chain=dev
-  #     - --bootnodes=/dns4/boot-node-1/tcp/30333/p2p/QmQmJTi2eDg53Ws3N5XaixMmiGCmhNNJX7bPBMirnD2JEs
-  #     - --ws-external
-  #     - --rpc-cors=all
-
-  # full-node-3:
-  #   image: plugnet/plugblockchain:1.0.0-rc1
-  #   container_name: full-node-3
-  #   volumes: ["./data/full-node-3:/mnt/node"]
-  #   command:
-      - /usr/local/bin/substrate
-  #     - --base-path=/mnt/node
-  #     - --chain=dev
-  #     - --bootnodes=/dns4/boot-node-1/tcp/30333/p2p/QmQmJTi2eDg53Ws3N5XaixMmiGCmhNNJX7bPBMirnD2JEs
-  #     - --ws-external
-  #     - --rpc-cors=all
-
-
-  

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@plugnet/plug-api-types": "git+https://github.com/plugblockchain/plug-api-types.git#1.0.0-rc1",
     "@polkadot/api": "0.96.1",
     "argparse": "1.0.10",
+    "console-log-level": "^1.4.1",
     "console-stamp": "^0.2.9",
     "mocha": "^6.2.2"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -17,35 +17,35 @@ const APP_FAIL_TRANSACTION_TIMEOUT = 2;
 async function main (settings) {
   const config = await setup(settings);
   const result = await run(config);
-  return result; 
+  return result;
 }
 
 async function setup(settings) {
   // Command line delay used to wait for nodes to come up
-  await sleep(settings.startup_delay_ms);  
+  await sleep(settings.startup_delay_ms);
 
   // Initialise the provider to connect to the local node
   console.log(`Connecting to ${settings.address}`);
   const provider = new WsProvider(settings.address);
-  
+
   // Create the API and wait until ready
-  const api = await ApiPromise.create({ 
+  const api = await ApiPromise.create({
     provider,
-    types: PlugRuntimeTypes.default 
+    types: PlugRuntimeTypes.default
   });
-  
+
   // Retrieve the chain & node information information via rpc calls
   const [chain, nodeName, nodeVersion] = await Promise.all([
     api.rpc.system.chain(),
     api.rpc.system.name(),
     api.rpc.system.version(),
   ]);
-  
+
   console.log(`You are connected to chain ${chain} using ${nodeName} v${nodeVersion}`);
 
   // The test ends when the final block number = start + delta
   const start_block_number = await getFinalizedBlockNumber(api)
-  
+
   // Gather all required users
   const keyring = testingPairs.default({ type: 'sr25519'});
 
@@ -55,15 +55,15 @@ async function setup(settings) {
   const steve_keyring = new Keyring.Keyring({type: 'sr25519'});
   const steves = createTheSteves(required_steves, steve_keyring);
 
-  if (settings.fund) {	
-    await fundTheSteves(	
-      steves, 	
-      api, 	
-      [keyring.alice, keyring.bob, keyring.charlie, keyring.ferdie, keyring.dave, keyring.eve], 	
-      settings.transaction.timeout_ms	
-      );	
+  if (settings.fund) {
+    await fundTheSteves(
+      steves,
+      api,
+      [keyring.alice, keyring.bob, keyring.charlie, keyring.ferdie, keyring.dave, keyring.eve],
+      settings.transaction.timeout_ms
+      );
   }
-  
+
   const keypair_selector = new selector.KeypairSelector(
     [keyring.ferdie]
     .concat(steves)
@@ -85,13 +85,13 @@ async function setup(settings) {
 }
 
 async function run(config) {
-  
+
   // SetInterval is used to ensure precise transaction rates
   let pending_transaction = 0;
   let interval = setInterval(function() {
     pending_transaction++;
   }, config.request_period_ms);
-  
+
   // These varaibles allow asynchronous functions to recommend script termination
   let app_complete = false;
   let app_error = null;
@@ -103,14 +103,14 @@ async function run(config) {
     // triggers a new transaction if needed
     if (pending_transaction > 0) {
       pending_transaction--;
-      
+
       let thrown_error = null;
-      
+
       var transaction = new Promise(async function(resolve, reject){
         const [sender, receiver] = config.keypair_selector.next();
         const transaction_hash = await makeTransaction(config.api, sender, receiver, config.funds, config.timeout_ms)
         .catch(err => thrown_error = err);
-        
+
         if (thrown_error != null) {
           reject(thrown_error);
         } else if (transaction_hash == null) {
@@ -119,30 +119,30 @@ async function run(config) {
           const header = await config.api.rpc.chain.getHeader(transaction_hash);
           console.log(`Transaction included on block ${header.number} with blockHash ${transaction_hash}`);
           resolve()
-        } 
+        }
       });
-      
+
       transaction.then(
         async function() {
           // Check if we have completed the test
           const block_delta = await getFinalizedBlockNumber(config.api) - config.start_block_number;
-          
+
           console.log(`At block: ${block_delta} of ${config.required_block_delta}`)
-          
+
           if (block_delta >= config.required_block_delta) {
             clearInterval(interval);
             app_complete = true;
-          }    
+          }
         },
         (err) => app_error = err
         );
-        
+
     } else if (app_complete) {
       return APP_SUCCESS;
-    } else if (app_error != null) {	
-      console.log(app_error);	
-      app_error = null	
-      await sleep(poll_period_ms);	
+    } else if (app_error != null) {
+      console.log(app_error);
+      app_error = null
+      await sleep(poll_period_ms);
     }  else {
       await sleep(poll_period_ms);
     }
@@ -154,7 +154,7 @@ async function getFinalizedBlockNumber(api) {
   const header = await api.rpc.chain.getHeader(hash);
   return header.number;
 }
-  
+
 async function makeTransaction(api, sender, receiver, funds, timeout_ms)  {
   const sleep_ms = 50;
   let timed_out = false;
@@ -165,7 +165,7 @@ async function makeTransaction(api, sender, receiver, funds, timeout_ms)  {
   let sender_balance = await api.query.balances.freeBalance(sender.address);
   let receiver_balance = await api.query.balances.freeBalance(receiver.address);
   console.log(
-    `${sender.meta.name} [${sender_balance}] =>`, 
+    `${sender.meta.name} [${sender_balance}] =>`,
     `${receiver.meta.name} [${receiver_balance}]`,
     `: Nonce - ${nonce.words}`
     );
@@ -174,7 +174,7 @@ async function makeTransaction(api, sender, receiver, funds, timeout_ms)  {
   const unsub = await api.tx.balances.transfer(receiver.address, funds)
   .signAndSend(sender, {nonce: nonce}, (result) => {
     console.log(`Current status is ${result.status}`);
-    
+
     if (result.isCompleted) {
       if (result.isFinalized) {
         hash = result.status.asFinalized;
@@ -187,9 +187,9 @@ async function makeTransaction(api, sender, receiver, funds, timeout_ms)  {
     }
   })
   .catch(err => transaction_error = err);
-  
+
   const timer = setTimeout(() => timed_out = true, timeout_ms);
-  
+
   // periodically checks whether we have timed out
   // avoided sleeping here so that we can report a successful transation at the time
   // it occurs.
@@ -203,7 +203,7 @@ async function makeTransaction(api, sender, receiver, funds, timeout_ms)  {
     }
     await sleep(sleep_ms);
   }
-  
+
   return hash;
 }
 
@@ -214,43 +214,43 @@ function createTheSteves(number, steve_keyring) {
   for (i=0;i<number; i++) {
     name = "Steve_0x" + (i).toString(16)
     console.log(`Steve Factory - Creating`, name);
-    
+
     let steve = steve_keyring.addFromUri(name, {name: name});
     steves.push(steve);
   }
-  
+
   return steves;
 }
 
-	/// Funds an array of Steve keypairs an adequate amount from a funder keypair	
-/// The Steves are funded enough that they should now be registered on the chain	
-async function fundTheSteves(steves, api, alice_and_friends, timeout_ms) {	
-  console.log(`Steve Factory - Funding All Steves.`)	
-  let len = alice_and_friends.length	
-  let busy = new Array(len).fill(false)	
-  let index = 0	
-  let steve;	
-  for (steve of steves) {	
-    let donor_index = index	
-    let donor = alice_and_friends[donor_index]	
-    	
-    index += 1	
-    if (index >= len) {	
-      index = 0	
-    }	
-    	
-    while (busy[donor_index]) {	
-      await sleep(10)	
-    }	
-    await sleep(100)	
-    busy[donor_index] = true	
-    let p = new Promise(async function(resolve, reject) {	
-      await makeTransaction(api, donor, steve, '100_000_000_000_000', timeout_ms)	
-      .catch( (err) => {throw err;});	
-      resolve(true);	
-    })	
-    p.then((_) => busy[donor_index] = false )	
-  }	
+	/// Funds an array of Steve keypairs an adequate amount from a funder keypair
+/// The Steves are funded enough that they should now be registered on the chain
+async function fundTheSteves(steves, api, alice_and_friends, timeout_ms) {
+  console.log(`Steve Factory - Funding All Steves.`)
+  let len = alice_and_friends.length
+  let busy = new Array(len).fill(false)
+  let index = 0
+  let steve;
+  for (steve of steves) {
+    let donor_index = index
+    let donor = alice_and_friends[donor_index]
+
+    index += 1
+    if (index >= len) {
+      index = 0
+    }
+
+    while (busy[donor_index]) {
+      await sleep(10)
+    }
+    await sleep(100)
+    busy[donor_index] = true
+    let p = new Promise(async function(resolve, reject) {
+      await makeTransaction(api, donor, steve, '100_000_000_000_000', timeout_ms)
+      .catch( (err) => {throw err;});
+      resolve(true);
+    })
+    p.then((_) => busy[donor_index] = false )
+  }
 }
 
 function sleep(ms) {
@@ -260,10 +260,10 @@ function sleep(ms) {
 
 if (require.main === module) {
   settings = cli.parseCliArguments();
-  
+
   main(settings)
     .then(result => process.exit(result))
-    .catch(fail => { 
+    .catch(fail => {
     console.error(`Error:`, fail);
     process.exit(fail[0]);
   });

--- a/src/app.js
+++ b/src/app.js
@@ -120,9 +120,9 @@ async function run(config) {
           .catch(err => thrown_error = err);
 
         if (thrown_error != null) {
-          reject(thrown_error, addr);
+          reject([thrown_error, addr]);
         } else if (transaction_hash == null) {
-          reject([APP_FAIL_TRANSACTION_TIMEOUT, "Transaction Timeout"], addr);
+          reject([[APP_FAIL_TRANSACTION_TIMEOUT, "Transaction Timeout"], addr]);
         } else {
           const header = await api.rpc.chain.getHeader(transaction_hash);
           log.info(`[${addr}] Transaction included on block ${header.number} with blockHash ${transaction_hash}`);
@@ -142,9 +142,9 @@ async function run(config) {
             app_complete = true;
           }
         },
-        (err, addr) => {
-          app_error = err;
-          log.error(`[${addr}] ${app_error}`);
+        (err) => {
+          app_error = err[0];
+          log.error(`[${err[1]}] ${app_error}`);
         }
       );
 

--- a/src/app.js
+++ b/src/app.js
@@ -29,7 +29,7 @@ async function setup(settings) {
   // Initialise the provider to connect to the local node
   const apis = [];
   for (let i = 0; i < settings.address.length; i++) {
-    console.info(`Connecting to ${settings.address[i]}`);
+    log.info(`Connecting to ${settings.address[i]}`);
     const provider = new WsProvider(settings.address[i]);
 
     // Create the API and wait until ready
@@ -55,7 +55,7 @@ async function setup(settings) {
   const keyring = testingPairs.default({ type: 'sr25519'});
 
   const required_users = 2 * settings.transaction.timeout_ms / settings.transaction.period_ms;
-  const required_steves = Math.max(1, Math.floor(required_users - 6));
+  const required_steves = Math.max(2, Math.ceil(required_users));
 
   const steve_keyring = new Keyring.Keyring({type: 'sr25519'});
   const steves = createTheSteves(required_steves, steve_keyring);

--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,8 @@ const APP_SUCCESS = 0;
 const APP_FAIL_TRANSACTION_REJECTED = 1;
 const APP_FAIL_TRANSACTION_TIMEOUT = 2;
 
+let log = require('console-log-level')({ level: 'info' });
+
 async function main (settings) {
   const config = await setup(settings);
   const result = await run(config);
@@ -25,32 +27,35 @@ async function setup(settings) {
   await sleep(settings.startup_delay_ms);
 
   // Initialise the provider to connect to the local node
-  console.log(`Connecting to ${settings.address}`);
-  const provider = new WsProvider(settings.address);
+  const apis = [];
+  for (let i = 0; i < settings.address.length; i++) {
+    console.info(`Connecting to ${settings.address[i]}`);
+    const provider = new WsProvider(settings.address[i]);
 
-  // Create the API and wait until ready
-  const api = await ApiPromise.create({
-    provider,
-    types: PlugRuntimeTypes.default
-  });
+    // Create the API and wait until ready
+    const api = await ApiPromise.create({
+      provider,
+      types: PlugRuntimeTypes.default
+    });
+    apis.push(api);
 
-  // Retrieve the chain & node information information via rpc calls
-  const [chain, nodeName, nodeVersion] = await Promise.all([
-    api.rpc.system.chain(),
-    api.rpc.system.name(),
-    api.rpc.system.version(),
-  ]);
-
-  console.log(`You are connected to chain ${chain} using ${nodeName} v${nodeVersion}`);
+    // Retrieve the chain & node information information via rpc calls
+    const [chain, nodeName, nodeVersion] = await Promise.all([
+      api.rpc.system.chain(),
+      api.rpc.system.name(),
+      api.rpc.system.version(),
+    ]);
+    log.info(`You are connected to chain ${chain} using ${nodeName} v${nodeVersion}`);
+  }
 
   // The test ends when the final block number = start + delta
-  const start_block_number = await getFinalizedBlockNumber(api)
+  const start_block_number = await getFinalizedBlockNumber(apis[0])
 
   // Gather all required users
   const keyring = testingPairs.default({ type: 'sr25519'});
 
-  const required_users = 2*settings.transaction.timeout_ms/settings.transaction.period_ms;
-  const required_steves = Math.max(1, Math.floor(required_users-6));
+  const required_users = 2 * settings.transaction.timeout_ms / settings.transaction.period_ms;
+  const required_steves = Math.max(1, Math.floor(required_users - 6));
 
   const steve_keyring = new Keyring.Keyring({type: 'sr25519'});
   const steves = createTheSteves(required_steves, steve_keyring);
@@ -58,21 +63,21 @@ async function setup(settings) {
   if (settings.fund) {
     await fundTheSteves(
       steves,
-      api,
+      apis[0],
       [keyring.alice, keyring.bob, keyring.charlie, keyring.ferdie, keyring.dave, keyring.eve],
       settings.transaction.timeout_ms
-      );
+    );
   }
 
   const keypair_selector = new selector.KeypairSelector(
-    [keyring.ferdie]
-    .concat(steves)
-    );
+    [keyring.ferdie].concat(steves)
+  );
 
   const funds = 5;
 
   const config = {
-    api: api,
+    apis: apis,
+    addresses: settings.address,
     funds: funds,
     timeout_ms: settings.transaction.timeout_ms,
     request_period_ms: settings.transaction.period_ms,
@@ -95,6 +100,7 @@ async function run(config) {
   // These varaibles allow asynchronous functions to recommend script termination
   let app_complete = false;
   let app_error = null;
+  let api_idx = 0;
 
   const poll_period_ms = 10;
 
@@ -105,42 +111,51 @@ async function run(config) {
       pending_transaction--;
 
       let thrown_error = null;
+      const api = config.apis[api_idx];
 
       var transaction = new Promise(async function(resolve, reject){
+        const addr = config.addresses[api_idx];
         const [sender, receiver] = config.keypair_selector.next();
-        const transaction_hash = await makeTransaction(config.api, sender, receiver, config.funds, config.timeout_ms)
-        .catch(err => thrown_error = err);
+        const transaction_hash = await makeTransaction(api, sender, receiver, config.funds, config.timeout_ms)
+          .catch(err => thrown_error = err);
 
         if (thrown_error != null) {
-          reject(thrown_error);
+          reject(thrown_error, addr);
         } else if (transaction_hash == null) {
-          reject([APP_FAIL_TRANSACTION_TIMEOUT, "Transaction Timeout"])
+          reject([APP_FAIL_TRANSACTION_TIMEOUT, "Transaction Timeout"], addr);
         } else {
-          const header = await config.api.rpc.chain.getHeader(transaction_hash);
-          console.log(`Transaction included on block ${header.number} with blockHash ${transaction_hash}`);
-          resolve()
+          const header = await api.rpc.chain.getHeader(transaction_hash);
+          log.info(`[${addr}] Transaction included on block ${header.number} with blockHash ${transaction_hash}`);
+          resolve(addr);
         }
       });
 
       transaction.then(
-        async function() {
+        async function(addr) {
           // Check if we have completed the test
-          const block_delta = await getFinalizedBlockNumber(config.api) - config.start_block_number;
+          const block_delta = await getFinalizedBlockNumber(api) - config.start_block_number;
 
-          console.log(`At block: ${block_delta} of ${config.required_block_delta}`)
+          log.info(`[${addr}] At block: ${block_delta} of ${config.required_block_delta}`);
 
           if (block_delta >= config.required_block_delta) {
             clearInterval(interval);
             app_complete = true;
           }
         },
-        (err) => app_error = err
-        );
+        (err, addr) => {
+          app_error = err;
+          log.error(`[${addr}] ${app_error}`);
+        }
+      );
+
+      api_idx++;
+      if (api_idx == config.apis.length) {
+        api_idx = 0;
+      }
 
     } else if (app_complete) {
       return APP_SUCCESS;
     } else if (app_error != null) {
-      console.log(app_error);
       app_error = null
       await sleep(poll_period_ms);
     }  else {
@@ -160,33 +175,35 @@ async function makeTransaction(api, sender, receiver, funds, timeout_ms)  {
   let timed_out = false;
   let transaction_error = null;
   let hash = null;
-  // Verbose transaction information -- could be removed in the future
   let nonce = await api.query.system.accountNonce(sender.address);
+
+  // Verbose transaction information -- could be removed in the future
   let sender_balance = await api.query.balances.freeBalance(sender.address);
   let receiver_balance = await api.query.balances.freeBalance(receiver.address);
-  console.log(
+  log.info(
     `${sender.meta.name} [${sender_balance}] =>`,
     `${receiver.meta.name} [${receiver_balance}]`,
     `: Nonce - ${nonce.words}`
-    );
+  );
 
   // Sign and send a balance transfer
-  const unsub = await api.tx.balances.transfer(receiver.address, funds)
-  .signAndSend(sender, {nonce: nonce}, (result) => {
-    console.log(`Current status is ${result.status}`);
+  const unsub = await api.tx.balances
+    .transfer(receiver.address, funds)
+    .signAndSend(sender, {nonce: nonce}, (result) => {
+      log.info(`Current status is ${result.status}`);
 
-    if (result.isCompleted) {
-      if (result.isFinalized) {
-        hash = result.status.asFinalized;
+      if (result.isCompleted) {
+        if (result.isFinalized) {
+          hash = result.status.asFinalized;
+        }
+        else { // error
+          log.error("Transaction Rejected");
+          throw [APP_FAIL_TRANSACTION_REJECTED, `Transaction rejected ${result.status}`];
+        }
+        unsub();
       }
-      else { // error
-        console.log("Transaction Rejected");
-        throw [APP_FAIL_TRANSACTION_REJECTED, `Transaction rejected ${result.status}`];
-      }
-      unsub();
-    }
-  })
-  .catch(err => transaction_error = err);
+    })
+    .catch(err => transaction_error = err);
 
   const timer = setTimeout(() => timed_out = true, timeout_ms);
 
@@ -209,23 +226,22 @@ async function makeTransaction(api, sender, receiver, funds, timeout_ms)  {
 
 /// Generates a number of steve keypairs
 function createTheSteves(number, steve_keyring) {
-  console.log(`Steve Factory Initializing - Creating [${number}] Steves.`)
+  log.info(`Steve Factory Initializing - Creating [${number}] Steves.`)
   const steves = [];
   for (i=0;i<number; i++) {
     name = "Steve_0x" + (i).toString(16)
-    console.log(`Steve Factory - Creating`, name);
-
+    log.debug(`Steve Factory - Creating`, name);
     let steve = steve_keyring.addFromUri(name, {name: name});
     steves.push(steve);
   }
-
+  log.info(`Steve Factory - Created [${steves.length}] Steves.`)
   return steves;
 }
 
-	/// Funds an array of Steve keypairs an adequate amount from a funder keypair
+/// Funds an array of Steve keypairs an adequate amount from a funder keypair
 /// The Steves are funded enough that they should now be registered on the chain
 async function fundTheSteves(steves, api, alice_and_friends, timeout_ms) {
-  console.log(`Steve Factory - Funding All Steves.`)
+  log.info(`Steve Factory - Funding All Steves.`)
   let len = alice_and_friends.length
   let busy = new Array(len).fill(false)
   let index = 0
@@ -246,7 +262,7 @@ async function fundTheSteves(steves, api, alice_and_friends, timeout_ms) {
     busy[donor_index] = true
     let p = new Promise(async function(resolve, reject) {
       await makeTransaction(api, donor, steve, '100_000_000_000_000', timeout_ms)
-      .catch( (err) => {throw err;});
+        .catch( (err) => {throw err;});
       resolve(true);
     })
     p.then((_) => busy[donor_index] = false )
@@ -260,11 +276,12 @@ function sleep(ms) {
 
 if (require.main === module) {
   settings = cli.parseCliArguments();
+  log = require('console-log-level')({ level: settings.log_level });
 
   main(settings)
     .then(result => process.exit(result))
     .catch(fail => {
-    console.error(`Error:`, fail);
+    log.error(`Error:`, fail);
     process.exit(fail[0]);
   });
 } else {

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,11 +11,12 @@ function forceInt(value, default_value) {
 
 function parseCliArguments() {
   const default_ip_address = '127.0.0.1';
-  const default_port = 9944;
+  const default_port = '9944';
   const default_timeout_ms = 5000;
   const default_period_ms = 5000;
   const default_block_delta = 10000;
   const default_startup_delay_ms = 0;
+  const default_log_level = 'info';
 
 
   let parser = ArgParse.ArgumentParser()
@@ -23,8 +24,8 @@ function parseCliArguments() {
     ['--address'],
     {
       help: 'IP address of the node for sending transactions',
-      defaultValue: [default_ip_address, default_port],
-      metavar: ['ip-addr', 'port-num'],
+      defaultValue: [default_ip_address],
+      metavar: ['ip-addr'],
       nargs: '+',
       dest: 'address'
     }
@@ -80,25 +81,16 @@ function parseCliArguments() {
     }
   );
   parser.addArgument(
-    ['--verbose'],
+    ['--log-level'],
     {
-      help: 'Run in verbose mode',
-      defaultValue: false,
-      action: 'storeTrue',
-      nargs: '0',
-      dest: 'verbose'
+      help: 'Set log-level',
+      defaultValue: default_log_level,
+      nargs: '1',
+      dest: 'log_level'
     }
   );
 
   let args = parser.parseArgs()
-
-  // Fill in any blanks for the address config
-  if (args.address.length == 1) {
-    args.address.push(default_port);
-  }
-  else if (args.address.length >= 2) {
-    args.address[1] = forceInt(args.address[1], default_port);
-  }
 
   // Force all integers to be integers
   args.timeout_ms = forceInt(args.timeout_ms, default_timeout_ms);
@@ -106,9 +98,19 @@ function parseCliArguments() {
   args.block_delta = forceInt(args.block_delta, default_block_delta);
   args.startup_delay_ms = forceInt(args.startup_delay_ms, default_startup_delay_ms);
 
+  // Format addresses and port correctly
+  let addresses = [];
+  for (let i = 0; i < args.address.length; i++) {
+    // Add default port if not specified
+    if (args.address[i].split(':').length == 1) {
+      args.address[i] = [args.address[i], default_port].join(":")
+    }
+    addresses.push(`ws://${args.address[i]}`);
+  }
+
   // Return a settings object
   let settings = {
-    address: `ws://${args.address[0]}:${args.address[1]}`,
+    address: addresses,
     startup_delay_ms: args.startup_delay_ms,
     transaction: {
       timeout_ms: args.timeout_ms,
@@ -118,7 +120,7 @@ function parseCliArguments() {
       block_delta: args.block_delta
     },
     fund: args.fund,
-    verbose: args.verbose
+    log_level: Array.isArray(args.log_level) ? args.log_level[0] : args.log_level
   }
   return settings;
 }
@@ -133,4 +135,3 @@ if (require.main === module) {
     parseCliArguments: parseCliArguments
   }
 }
-

--- a/src/cli.js
+++ b/src/cli.js
@@ -79,6 +79,16 @@ function parseCliArguments() {
       dest: 'fund'
     }
   );
+  parser.addArgument(
+    ['--verbose'],
+    {
+      help: 'Run in verbose mode',
+      defaultValue: false,
+      action: 'storeTrue',
+      nargs: '0',
+      dest: 'verbose'
+    }
+  );
 
   let args = parser.parseArgs()
 
@@ -107,14 +117,15 @@ function parseCliArguments() {
     exit: {
       block_delta: args.block_delta
     },
-    fund: args.fund
+    fund: args.fund,
+    verbose: args.verbose
   }
   return settings;
 }
 
 if (require.main === module) {
   settings = parseCliArguments()
-  
+
   console.log(settings)
 } else {
   // Export modules for testing

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -5,31 +5,38 @@ describe('Command Line Interface - IP Address', function() {
   it('Default Address', function() {
     process.argv = 'node cli.test.js'.split(' ');
     result = cli.parseCliArguments();
-    assert.equal(result.address, "ws://127.0.0.1:9944");
+    assert.equal(result.address.length, 1);
+    assert.equal(result.address[0], "ws://127.0.0.1:9944");
   });
 
   it('New Address', function() {
-    process.argv = 'node cli.test.js --address 0.0.0.0 1234'.split(' ');
+    process.argv = 'node cli.test.js --address 0.0.0.0:1234'.split(' ');
     result = cli.parseCliArguments();
-    assert.equal(result.address, "ws://0.0.0.0:1234");
+    assert.equal(result.address.length, 1);
+    assert.equal(result.address[0], "ws://0.0.0.0:1234");
   });
 
   it('Change ip address only', function() {
     process.argv = 'node cli.test.js --address 0.0.0.0'.split(' ');
     result = cli.parseCliArguments();
-    assert.equal(result.address, "ws://0.0.0.0:9944");
+    assert.equal(result.address.length, 1);
+    assert.equal(result.address[0], "ws://0.0.0.0:9944");
   });
 
   it('IP address can be a string', function() {
-    process.argv = 'node cli.test.js --address node 1234'.split(' ');
+    process.argv = 'node cli.test.js --address node:1234'.split(' ');
     result = cli.parseCliArguments();
-    assert.equal(result.address, "ws://node:1234");
+    assert.equal(result.address.length, 1);
+    assert.equal(result.address[0], "ws://node:1234");
   });
 
-  it('Port must be a number', function() {
-    process.argv = 'node cli.test.js --address 0.0.0.0 five'.split(' ');
+  it('Can have multiple addresses', function() {
+    process.argv = 'node cli.test.js --address 0.0.0.0:1 0.0.0.0:2 0.0.0.0:3'.split(' ');
     result = cli.parseCliArguments();
-    assert.equal(result.address, "ws://0.0.0.0:9944");
+    let tests = ["ws://0.0.0.0:1", "ws://0.0.0.0:2", "ws://0.0.0.0:3"];
+    for (let i = 0; i < result.address.length; i++) {
+      assert.equal(result.address[i], tests[i]);
+    }
   });
 });
 
@@ -86,7 +93,7 @@ describe('Command Line Interface - Block Exit Condition', function() {
   });
 });
 
-describe('Command Line Interface - All Other Params', function() {
+describe('Command Line Interface - Fund', function() {
   it('Should not fund steves by default', function () {
     process.argv = 'node cli.test.js'.split(' ');
     result = cli.parseCliArguments();
@@ -98,16 +105,18 @@ describe('Command Line Interface - All Other Params', function() {
     result = cli.parseCliArguments();
     assert.equal(result.fund, true);
   });
+});
 
-  it('Should not run in verbose mode by default', function () {
+describe('Command Line Interface - Log Level', function () {
+  it('Should set log-level info by default', function () {
     process.argv = 'node cli.test.js'.split(' ');
     result = cli.parseCliArguments();
-    assert.equal(result.verbose, false);
+    assert.equal(result.log_level, 'info');
   });
 
-  it('Should run in verbose mode with flag set', function () {
-    process.argv = 'node cli.test.js --verbose'.split(' ');
+  it('Should set log-level', function () {
+    process.argv = 'node cli.test.js --log-level debug'.split(' ');
     result = cli.parseCliArguments();
-    assert.equal(result.verbose, true);
+    assert.equal(result.log_level, 'debug');
   });
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -3,29 +3,29 @@ const cli = require('../src/cli.js');
 
 describe('Command Line Interface - IP Address', function() {
   it('Default Address', function() {
-    process.argv = ['node','cli.test.js'];
+    process.argv = 'node cli.test.js'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.address, "ws://127.0.0.1:9944");
   });
-  
+
   it('New Address', function() {
     process.argv = 'node cli.test.js --address 0.0.0.0 1234'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.address, "ws://0.0.0.0:1234");
   });
-  
+
   it('Change ip address only', function() {
     process.argv = 'node cli.test.js --address 0.0.0.0'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.address, "ws://0.0.0.0:9944");
   });
-  
+
   it('IP address can be a string', function() {
     process.argv = 'node cli.test.js --address node 1234'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.address, "ws://node:1234");
   });
-  
+
   it('Port must be a number', function() {
     process.argv = 'node cli.test.js --address 0.0.0.0 five'.split(' ');
     result = cli.parseCliArguments();
@@ -35,30 +35,30 @@ describe('Command Line Interface - IP Address', function() {
 
 describe('Command Line Interface - Transaction Params', function() {
   it('Default Timing', function() {
-    process.argv = ['node','cli.test.js'];
+    process.argv = 'node cli.test.js'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.transaction.timeout_ms, 5000);
     assert.equal(result.transaction.period_ms, 5000);
   });
-  
+
   it('Set timeout', function() {
     process.argv = 'node cli.test.js --timeout 1234'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.transaction.timeout_ms, 1234);
   });
-  
+
   it('Set period', function() {
     process.argv = 'node cli.test.js --period 1234'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.transaction.period_ms, 1234);
   });
-  
+
   it('Set bad timeout', function() {
     process.argv = 'node cli.test.js --timeout five'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.transaction.timeout_ms, 5000);
   });
-  
+
   it('Set bad period', function() {
     process.argv = 'node cli.test.js --period five'.split(' ');
     result = cli.parseCliArguments();
@@ -68,20 +68,46 @@ describe('Command Line Interface - Transaction Params', function() {
 
 describe('Command Line Interface - Block Exit Condition', function() {
   it('Default block delta', function() {
-    process.argv = ['node','cli.test.js'];
+    process.argv = 'node cli.test.js'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.exit.block_delta, 10000);
   });
-  
+
   it('Set block delta', function() {
     process.argv = 'node cli.test.js --target-block 1234'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.exit.block_delta, 1234);
   });
-    
+
   it('Set bad block delta', function() {
     process.argv = 'node cli.test.js --target-block five'.split(' ');
     result = cli.parseCliArguments();
     assert.equal(result.exit.block_delta, 10000);
+  });
+});
+
+describe('Command Line Interface - All Other Params', function() {
+  it('Should not fund steves by default', function () {
+    process.argv = 'node cli.test.js'.split(' ');
+    result = cli.parseCliArguments();
+    assert.equal(result.fund, false);
+  });
+
+  it('Should fund steves with flag set', function () {
+    process.argv = 'node cli.test.js --fund'.split(' ');
+    result = cli.parseCliArguments();
+    assert.equal(result.fund, true);
+  });
+
+  it('Should not run in verbose mode by default', function () {
+    process.argv = 'node cli.test.js'.split(' ');
+    result = cli.parseCliArguments();
+    assert.equal(result.verbose, false);
+  });
+
+  it('Should run in verbose mode with flag set', function () {
+    process.argv = 'node cli.test.js --verbose'.split(' ');
+    result = cli.parseCliArguments();
+    assert.equal(result.verbose, true);
   });
 });


### PR DESCRIPTION
Changes:
- `--address` is an array
- api object is now an array, each of which is for a node
- log-level is set using console-log-level package via `--log`
- associated unit tests are added
